### PR TITLE
No space left on device 

### DIFF
--- a/buildkitd-privileged.jsonnet
+++ b/buildkitd-privileged.jsonnet
@@ -76,8 +76,20 @@
                   containerPort: 1234
                 }
               ],
+              volumeMounts: [
+                {
+                  mountPath: "/var/lib/buildkit",
+                  name: "buildkit-root",
+                }
+              ],
             }
           ],
+          volumes: [
+            {
+              name: "buildkit-root",
+              emptyDir: {}
+            }
+          ]
         }
       }
     }

--- a/buildkitd-rootless.jsonnet
+++ b/buildkitd-rootless.jsonnet
@@ -72,8 +72,20 @@
                   containerPort: 1234
                 }
               ],
+              volumeMounts: [
+                {
+                  mountPath: "/var/lib/buildkit",
+                  name: "buildkit-root",
+                }
+              ],
             }
           ],
+          volumes: [
+            {
+              name: "buildkit-root",
+              emptyDir: {}
+            }
+          ]
         }
       }
     }

--- a/install-privileged.sh
+++ b/install-privileged.sh
@@ -19,7 +19,7 @@ if ! kubectl get namespace "${NS}" &> /dev/null; then
   kubectl create namespace "${NS}"
 fi
 kubectl patch namespace "${NS}" --type merge --patch '{"metadata":{"annotations":{"openshift.io/sa.scc.supplemental-groups":"1000/1", "openshift.io/sa.scc.uid-range": "1000/1"}}}'
-set -x
+
 if ! kubectl get serviceaccount "${SA}" -n "${NS}" &> /dev/null; then
   kubectl create serviceaccount "${SA}" -n "${NS}"
 fi


### PR DESCRIPTION
Large build images need more space than 32G provided by default in okd container for root `/`. 

Related to: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4452